### PR TITLE
disabled annoying lints

### DIFF
--- a/pkg/tools/golang/golangci.yaml
+++ b/pkg/tools/golang/golangci.yaml
@@ -50,6 +50,7 @@ linters:
     - maintidx
     - nlreturn
     - nonamedreturns
+    - nolintlint
     - paralleltest
     - prealloc
     - testpackage
@@ -97,10 +98,12 @@ linters-settings:
       - name: dot-imports
       - name: error-naming
       - name: error-return
-      - name: error-strings
-        arguments:
-          - "sdkerrors.Wrap"
-          - "sdkerrors.Wrapf"
+      # error-strings disallows any string starting with capital letter.
+      # In particular it disallows starting error messages with names of public functions, which is annoying.
+      #- name: error-strings
+      #  arguments:
+      #    - "sdkerrors.Wrap"
+      #    - "sdkerrors.Wrapf"
       - name: errorf
       - name: exported
       - name: if-return


### PR DESCRIPTION
Disabled errors-string (which is annoying) and nolintlint (which conflicts with gofmt).